### PR TITLE
Add fuzzy search filter

### DIFF
--- a/app/components/Input.tsx
+++ b/app/components/Input.tsx
@@ -3,7 +3,8 @@ import type { InputHTMLAttributes } from "react";
 import type { ClassProps } from "~/lib/props";
 
 const input = cva({
-    base: "rounded-lg border-2 border-black bg-white p-2 font-serif-text shadow-hard focus:outline-none dark:bg-[#232326] dark:text-white",
+    base:
+        "w-full rounded-lg border-2 border-black bg-white p-2 font-serif-text shadow-hard focus:outline-none dark:bg-[#232326] dark:text-white",
 });
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement>, ClassProps {}

--- a/app/components/Input.tsx
+++ b/app/components/Input.tsx
@@ -1,0 +1,13 @@
+import { cva } from "cva";
+import type { InputHTMLAttributes } from "react";
+import type { ClassProps } from "~/lib/props";
+
+const input = cva({
+    base: "rounded-lg border-2 border-black bg-white p-2 font-serif-text shadow-hard focus:outline-none dark:bg-[#232326] dark:text-white",
+});
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement>, ClassProps {}
+
+export function Input({ className, ...props }: InputProps) {
+    return <input className={input({ className })} {...props} />;
+}

--- a/app/components/filters/Filters.tsx
+++ b/app/components/filters/Filters.tsx
@@ -1,10 +1,11 @@
 import { DisclosureGroup } from "react-aria-components";
 import * as Stars from "./Stars";
+import { Search } from "./Search";
 
 export function Filters() {
     return (
         <DisclosureGroup className="sticky top-0 mx-20 hidden h-screen pt-10 lg:block">
-            {/* TODO: Search */}
+            <Search />
             {/* TODO: Tags */}
             <Stars.Filter />
             {/* TODO: Date? */}

--- a/app/components/filters/Search.tsx
+++ b/app/components/filters/Search.tsx
@@ -1,38 +1,52 @@
-import { Form, useLoaderData, useNavigate, useSearchParams } from "react-router";
 import { useEffect } from "react";
-import { Input } from "../Input";
+import { Form, useLoaderData, useNavigate, useSubmit } from "react-router";
 import type { Route } from "../../routes/_index/+types/route";
+import { Input } from "../Input";
+
+// const navigation = useNavigation()
+// const { contacts, q } = loaderData
+
+// const searching = Boolean(
+//     navigation.location && new URLSearchParams(navigation.location.search).has("q"),
+// )
+
+// const submit = useSubmit()
+// const navigate = useNavigate()
 
 export function Search() {
     const { stars, query } = useLoaderData() as Route.ComponentProps["loaderData"];
-    const [searchParams] = useSearchParams();
+    // const navigation = useNavigation();
+    // const searching = Boolean(
+    //     navigation.location && new URLSearchParams(navigation.location.search).has("q"),
+    // );
+
+    const submit = useSubmit();
     const navigate = useNavigate();
 
     useEffect(() => {
         if (document) {
-            const input = document.querySelector<HTMLInputElement>("#q");
-            if (input) {
-                input.value = query ?? "";
-            }
+            document.querySelector<HTMLInputElement>("#q")!.value = query ?? "";
         }
     }, [query]);
 
     return (
         <Form className="px-4 pb-8" method="get">
-            {stars !== null && <input type="hidden" name="stars" value={stars} />}
+            {stars !== null && <input name="stars" type="hidden" value={stars} />}
             <Input
                 aria-label="Search recommendations"
                 defaultValue={query ?? ""}
                 id="q"
                 name="q"
                 onInput={(event) => {
-                    const params = new URLSearchParams(searchParams);
+                    // Remove empty query params when value is empty
                     if (!event.currentTarget.value) {
-                        params.delete("q");
-                    } else {
-                        params.set("q", event.currentTarget.value);
+                        navigate("/");
+                        return;
                     }
-                    navigate(`?${params.toString()}`, { replace: query !== null });
+                    const isFirstSearch = query === undefined;
+                    submit(event.currentTarget.form, {
+                        replace: !isFirstSearch,
+                    });
                 }}
                 placeholder="Search..."
                 type="search"

--- a/app/components/filters/Search.tsx
+++ b/app/components/filters/Search.tsx
@@ -1,0 +1,42 @@
+import { Form, useLoaderData, useNavigate, useSearchParams } from "react-router";
+import { useEffect } from "react";
+import { Input } from "../Input";
+import type { Route } from "../../routes/_index/+types/route";
+
+export function Search() {
+    const { stars, query } = useLoaderData() as Route.ComponentProps["loaderData"];
+    const [searchParams] = useSearchParams();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (document) {
+            const input = document.querySelector<HTMLInputElement>("#q");
+            if (input) {
+                input.value = query ?? "";
+            }
+        }
+    }, [query]);
+
+    return (
+        <Form className="px-4 pb-8" method="get">
+            {stars !== null && <input type="hidden" name="stars" value={stars} />}
+            <Input
+                aria-label="Search recommendations"
+                defaultValue={query ?? ""}
+                id="q"
+                name="q"
+                onInput={(event) => {
+                    const params = new URLSearchParams(searchParams);
+                    if (!event.currentTarget.value) {
+                        params.delete("q");
+                    } else {
+                        params.set("q", event.currentTarget.value);
+                    }
+                    navigate(`?${params.toString()}`, { replace: query !== null });
+                }}
+                placeholder="Search..."
+                type="search"
+            />
+        </Form>
+    );
+}

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -1,18 +1,13 @@
 import { ArrowPathIcon, ExclamationTriangleIcon } from "@heroicons/react/20/solid";
 import { AnimatePresence, motion } from "motion/react";
-import {
-    isRouteErrorResponse,
-    useNavigate,
-    useSearchParams,
-} from "react-router";
-import { useMemo } from "react";
-import { Recommendation } from "~/components/Recommendation";
+import { isRouteErrorResponse, useNavigate } from "react-router";
 import { Filters } from "~/components/filters/Filters";
+import { Recommendation } from "~/components/Recommendation";
 import { getCollection } from "~/lib/content";
 import { stores } from "~/lib/stores.client";
-import { filterRecs, Stars, Query } from "./utilities";
-import type { Route } from "./+types/route";
 import { TokenButton } from "../../components/Token";
+import type { Route } from "./+types/route";
+import { filterRecs, Query, Stars } from "./utilities";
 
 export async function loader({ request }: Route.LoaderArgs) {
     let collection = await getCollection("recommendations");
@@ -86,28 +81,15 @@ export async function clientLoader({ request, serverLoader }: Route.ClientLoader
 }
 
 export default function Component({ loaderData }: Route.ComponentProps) {
-    const [searchParams] = useSearchParams();
-    const query = searchParams.get("q");
-
-    const filteredRecs = useMemo(
-        () =>
-            filterRecs({
-                recs: loaderData.recs,
-                stars: loaderData.stars,
-                query,
-            }),
-        [loaderData.recs, loaderData.stars, query],
-    );
-
     return (
         <div className="noise-container p-6">
             <div className="noise" />
             <div className="noise-underlay" />
-            <h1 className="font-serif-display text-5xl font-bold sm:text-6xl">Recommendations</h1>
+            <h1 className="font-bold font-serif-display text-5xl sm:text-6xl">Recommendations</h1>
             <div className="block sm:grid-cols-[3fr_2fr] lg:grid">
                 <div className="flex flex-col items-start gap-7 py-10">
                     <AnimatePresence>
-                        {filteredRecs.map((rec) => (
+                        {loaderData.filteredRecs.map((rec) => (
                             <motion.div className="w-full" key={rec.slug} layout>
                                 <Recommendation recommendation={rec} />
                             </motion.div>
@@ -138,7 +120,7 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
     return (
         <div className="flex h-screen flex-col justify-center px-4 py-6 text-center sm:px-64 sm:py-8">
             <ExclamationTriangleIcon className="mx-auto h-12 w-12 text-amber-500 dark:text-purple-500" />
-            <h3 className="mt-2 font-sans text-4xl font-semibold text-amber-950 dark:text-purple-200">
+            <h3 className="mt-2 font-sans font-semibold text-4xl text-amber-950 dark:text-purple-200">
                 {message}
             </h3>
             <p className="mt-1 font-serif-text text-amber-950 dark:text-purple-200">
@@ -147,7 +129,7 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
             <div className="mt-6">
                 <TokenButton onClick={() => navigate(0)} type="button">
                     <div className="flex flex-row items-center">
-                        <ArrowPathIcon aria-hidden="true" className="mr-1.5 -ml-0.5 h-5 w-5" />
+                        <ArrowPathIcon aria-hidden="true" className="-ml-0.5 mr-1.5 h-5 w-5" />
                         Refresh
                     </div>
                 </TokenButton>

--- a/app/routes/_index/utilities.ts
+++ b/app/routes/_index/utilities.ts
@@ -1,3 +1,4 @@
+import Fuse from "fuse.js";
 import type { HydratedRec } from "~/lib/data";
 
 export class Stars {
@@ -9,8 +10,37 @@ export class Stars {
     }
 }
 
-export function filterRecs({ recs, stars }: { recs: HydratedRec[]; stars: Stars }): HydratedRec[] {
-    return recs
-        .filter((rec) => (stars.count !== null ? rec.stars === stars.count : true))
-        .sort((lhs, rhs) => rhs.createdOn.getTime() - lhs.createdOn.getTime());
+export class Query {
+    readonly value: string | null;
+
+    constructor(request: Request) {
+        const query = new URL(request.url).searchParams.get("q");
+        this.value = query && query.trim().length > 0 ? query : null;
+    }
+}
+
+export function filterRecs(
+    {
+        recs,
+        stars,
+        query,
+    }: { recs: HydratedRec[]; stars: number | null; query: string | null },
+): HydratedRec[] {
+    let filtered = recs;
+
+    if (query) {
+        const fuse = new Fuse(recs, {
+            keys: ["title", "description", "tags.name"],
+            threshold: 0.4,
+        });
+        filtered = fuse.search(query).map((r) => r.item);
+    }
+
+    filtered = filtered.filter((rec) =>
+        stars !== null ? rec.stars === stars : true
+    );
+
+    return filtered.sort((lhs, rhs) =>
+        rhs.createdOn.getTime() - lhs.createdOn.getTime()
+    );
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -40,6 +40,7 @@
         "isbot": "npm:isbot@^5.1.23",
         "marked": "npm:marked@^15.0.7",
         "motion": "npm:motion@^12.4.10",
+        "fuse.js": "npm:fuse.js@^6.6.2",
         "react": "npm:react@^19.1.0",
         "react-aria-components": "npm:react-aria-components@^1.7.0",
         "react-dom": "npm:react-dom@^19.1.0",

--- a/deno.lock
+++ b/deno.lock
@@ -24,6 +24,7 @@
     "npm:cva@^1.0.0-beta.3": "1.0.0-beta.4",
     "npm:devalue@^5.1.1": "5.1.1",
     "npm:front-matter@^4.0.2": "4.0.2",
+    "npm:fuse.js@^6.6.2": "6.6.2",
     "npm:idb-keyval@^6.2.1": "6.2.2",
     "npm:isbot@^5.1.23": "5.1.28",
     "npm:marked@^15.0.7": "15.0.12",
@@ -2882,6 +2883,9 @@
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
+    "fuse.js@6.6.2": {
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
+    },
     "gensync@1.0.0-beta.2": {
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
@@ -3871,6 +3875,7 @@
       "npm:cva@^1.0.0-beta.3",
       "npm:devalue@^5.1.1",
       "npm:front-matter@^4.0.2",
+      "npm:fuse.js@^6.6.2",
       "npm:idb-keyval@^6.2.1",
       "npm:isbot@^5.1.23",
       "npm:marked@^15.0.7",


### PR DESCRIPTION
## Summary
- add new `<Input />` component for consistent input styling
- implement a search box in filter sidebar
- add keyword search using Fuse.js
- expose query parameter in loader and clientLoader
- configure fuse.js dependency
- enable client-side search filtering as the user types

## Testing
- `deno task typecheck` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_683fd312ca5c8320a2b3bc5d98cfe0f4